### PR TITLE
Fix for heartbleed ssl vuln in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@
 FROM ubuntu:12.10
 
 # Update OS.
-RUN echo "deb http://archive.ubuntu.com/ubuntu quantal main universe multiverse" > /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu quantal multiverse" >> /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu quantal-updates multiverse" >> /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu quantal-security multiverse" >> /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get upgrade -y
 


### PR DESCRIPTION
### Adds multiverse without removing security updates

This pull request changes how the `multiverse` distro is added to `/etc/apt/sources` such that the `quantal-updates` and `quantal-security` repos are not overridden. Without this change, the installed `openssl` version is vulnerable to the [heartbleed](http://heartbleed.com/) bug.
